### PR TITLE
fix frame calculation to eliminate letterboxing

### DIFF
--- a/src/components/ui/room-view.tsx
+++ b/src/components/ui/room-view.tsx
@@ -28,9 +28,16 @@ function calculateArtworkScale(dimensions: { width: number; height: number }) {
   const benchPixelWidth = 384 // pixels in our room
   const pixelsPerInch = benchPixelWidth / benchRealWidth
   
+  // Calculate inner dimensions first (what the image area should be)
+  const innerWidth = dimensions.width * pixelsPerInch
+  const innerHeight = dimensions.height * pixelsPerInch
+  
+  // Add padding back to get frame dimensions (p-3 = 12px on all sides)
+  const paddingTotal = 24 // 12px * 2 sides
+  
   return {
-    width: dimensions.width * pixelsPerInch,
-    height: dimensions.height * pixelsPerInch
+    width: innerWidth + paddingTotal,
+    height: innerHeight + paddingTotal
   }
 }
 


### PR DESCRIPTION
Calculate inner dimensions first, then add padding to get frame size. This ensures the inner container maintains the exact aspect ratio of the artwork, eliminating letterboxing with objectFit: contain.

🤖 Generated with [Claude Code](https://claude.ai/code)