### PR TITLE
eliminate hydration flashes by removing client/server state mismatch

### DIFF
--- a/src/app/[collection-name]/page.tsx
+++ b/src/app/[collection-name]/page.tsx
@@ -2,15 +2,19 @@
 
 import CardWithImage from "@/components/ui/card-with-image";
 import { getCollection } from "@/data/art-data";
-import { useParams, useRouter } from 'next/navigation';
-import { useState, useEffect } from "react";
+import { useParams, useRouter, usePathname } from 'next/navigation';
+import { Suspense } from "react";
 import ArtworkModal from "@/components/ui/artwork-modal";
 
-export default function Page() { 
+function CollectionContent() {
   const collectionName = useParams()['collection-name'];
   const router = useRouter();
+  const pathname = usePathname();
   const collectionImages = getCollection(collectionName.toString());
-  const [selectedImage, setSelectedImage] = useState<string | null>(null);
+  
+  // Determine modal state directly from URL without local state
+  const pathParts = pathname.split('/').filter(Boolean);
+  const selectedImage = pathParts.length === 2 && pathParts[0] === collectionName ? pathParts[1] : null;
 
   const formatTitleForURL = (title: string) => {
     return title.replace(/\s+/g, '-').toLowerCase();
@@ -21,12 +25,10 @@ export default function Page() {
     sessionStorage.setItem(`scroll-${collectionName}`, window.scrollY.toString());
     
     const imageUrl = formatTitleForURL(image.title);
-    setSelectedImage(imageUrl);
     router.push(`/${image.theme}/${imageUrl}`);
   };
 
   const handleCloseModal = () => {
-    setSelectedImage(null);
     router.push(`/${collectionName}`, { scroll: false });
   };
 
@@ -58,5 +60,13 @@ export default function Page() {
         />
       )}
     </div>
+  );
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={<div className="w-full h-lvh bg-black"></div>}>
+      <CollectionContent />
+    </Suspense>
   );
 }

--- a/src/components/ui/artwork-modal.tsx
+++ b/src/components/ui/artwork-modal.tsx
@@ -59,8 +59,8 @@ export default function ArtworkModal({ imageName, collectionName, onClose }: Art
   if (!imageData) {
     return (
       <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-        <div className="bg-white p-6 rounded-lg">
-          <p>Image not found</p>
+        <div className="bg-black p-6 rounded-lg">
+          <p className="text-white">Image not found</p>
           <Button onClick={onClose} className="mt-4">Close</Button>
         </div>
       </div>
@@ -71,11 +71,10 @@ export default function ArtworkModal({ imageName, collectionName, onClose }: Art
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-lg max-w-6xl w-full max-h-[90vh] overflow-y-auto">
-        <div className="sticky top-0 bg-white border-b p-4 flex justify-between items-center">
+      <div className="bg-black rounded-lg max-w-6xl w-full max-h-[90vh] overflow-y-auto">
+        <div className="sticky top-0 bg-black border-b p-4 flex justify-between items-center">
           <div>
             <h1 className="text-2xl font-bold">{title}</h1>
-            <p className="text-gray-600">Dimensions: {size}</p>
           </div>
           <Button
             variant="ghost"
@@ -97,7 +96,7 @@ export default function ArtworkModal({ imageName, collectionName, onClose }: Art
             onViewChange={handleViewChange}
           />
           
-          <CardFooter className="pt-6 mt-8 rounded-lg border bg-card text-card-foreground shadow-sm">
+          <CardFooter className="pt-6 mt-8 rounded-lg border bg-black text-white shadow-sm">
             <Link href="#" className="w-full">
               <Button className="w-full">
                 Buy Prints

--- a/src/components/ui/artwork-tabs.tsx
+++ b/src/components/ui/artwork-tabs.tsx
@@ -87,7 +87,7 @@ export default function ArtworkTabs({ title, description, size, src, className, 
         )}
 
         {activeTab === 'details' && (
-          <Card>
+          <Card className="bg-black border-gray-700">
             <CardContent className="space-y-4">
               <div>
                 <h3 className="font-semibold mb-2 text-white">Description</h3>

--- a/src/components/ui/image-with-zoom.tsx
+++ b/src/components/ui/image-with-zoom.tsx
@@ -41,9 +41,9 @@ export default function ImageWithZoom({
   }
 
   return (
-    <div className={cn("flex gap-4", className)}>
+    <div className={cn("relative", className)}>
       <div 
-        className="relative flex-1 overflow-hidden rounded-md border bg-black md:cursor-crosshair"
+        className="relative overflow-hidden rounded-md border bg-black md:cursor-crosshair"
         onMouseMove={handleMouseMove}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
@@ -60,7 +60,7 @@ export default function ImageWithZoom({
       </div>
       
       {isHovered && showZoomOnHover && (
-        <div className="relative w-[400px] h-[400px] border rounded-md overflow-hidden bg-black hidden md:block">
+        <div className="absolute top-0 right-[-420px] w-[400px] h-[400px] border rounded-md overflow-hidden bg-black hidden md:block">
           <Image
             src={src}
             fill


### PR DESCRIPTION
- Replace useState selectedImage with direct URL-based modal state
- Use usePathname to determine modal visibility without local state
- Wrap component in Suspense boundary with black fallback
- Fix ImageWithZoom layout from flex to absolute positioning to prevent width changes
- Remove dimensions from modal header to prevent flickering
- Ensure all modal backgrounds are consistently black
- Eliminates hamburger→back arrow flash and modal width inconsistencies

🤖 Generated with [Claude Code](https://claude.ai/code)