### PR TITLE
set global background color to black in CSS variables

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,7 +6,7 @@
   
 @layer base {
   :root {
-    --background: 0 0% 100%;
+    --background: 0 0% 0%;
     --foreground: 222.2 84% 4.9%;
     --card: 0 0% 100%;
     --card-foreground: 222.2 84% 4.9%;


### PR DESCRIPTION
- Change --background from 0 0% 100% (white) to 0 0% 0% (black)
- Ensures all bg-background classes throughout the site use black
- Affects main menu, card components, and other UI elements

🤖 Generated with [Claude Code](https://claude.ai/code)