### PR TITLE
clean up mobile hamburger button styling approach

### DIFF
--- a/src/components/main-menu/mobile/mobile-navigation-menu.tsx
+++ b/src/components/main-menu/mobile/mobile-navigation-menu.tsx
@@ -67,18 +67,14 @@ function MobileNavigationMenuContent() {
           <Drawer open={isMenuOpen} onOpenChange={setMenu} direction="left">
             <DrawerTrigger asChild>
               <Button
-                className="p-0 bg-transparent hover:bg-transparent"
+                className="p-0 bg-transparent hover:bg-transparent focus:ring-0 focus:outline-none"
                 variant="ghost"
+                style={{ 
+                  WebkitTapHighlightColor: 'transparent',
+                  outline: 'none'
+                }}
               >
-                <MenuIcon 
-                  color="white" 
-                  size={24} 
-                  style={{ 
-                    border: 'none', 
-                    outline: 'none',
-                    backgroundColor: 'transparent' 
-                  }}
-                />
+                <MenuIcon color="white" size={24} />
               </Button>
             </DrawerTrigger>
             <DrawerHeader className="flex flex-row justify-between items-center space-y-0 p-0">


### PR DESCRIPTION
- Remove direct MenuIcon styling, back to simple icon component
- Handle focus and tap highlights at Button level with focus:ring-0, focus:outline-none
- Add WebkitTapHighlightColor: transparent for iOS Safari tap highlights
- Cleaner separation of concerns: Button handles interaction states, Icon is just visual

🤖 Generated with [Claude Code](https://claude.ai/code)