### PR TITLE
add skeleton loading states to image components

### DIFF
--- a/src/components/ui/card-with-image.tsx
+++ b/src/components/ui/card-with-image.tsx
@@ -1,8 +1,10 @@
 import Image from "next/image"
+import { useState } from "react"
 
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import ImageWithZoom from "@/components/ui/image-with-zoom"
+import { Skeleton } from "@/components/ui/skeleton"
 import {
   Card,
   CardContent,
@@ -27,6 +29,7 @@ type ButtonProps = React.ComponentProps<typeof Button>
 
 export default function CardWithImage({ className, ...props }: CardWithImageProps & CardProps & ButtonProps) {
   const hasHeaderContent = props.title || props.dimensions || props.description;
+  const [isLoading, setIsLoading] = useState(true);
   
   return (
     <Card className={cn("w-11/12", className)} {...props}>
@@ -46,11 +49,20 @@ export default function CardWithImage({ className, ...props }: CardWithImageProp
         ) : (
           <div className="rounded-md border">
             <div className="relative h-[400px] w-full">
+              {isLoading && (
+                <Skeleton className="absolute inset-0 h-full w-full rounded-md" />
+              )}
               <Image 
                 src={props.src}
                 fill
                 alt={props.description!}
-                style={{objectFit: 'cover', borderRadius: '0.375rem'}}   
+                style={{objectFit: 'cover', borderRadius: '0.375rem'}}
+                className={cn(
+                  "transition-opacity duration-200",
+                  isLoading ? "opacity-0" : "opacity-100"
+                )}
+                onLoad={() => setIsLoading(false)}
+                onError={() => setIsLoading(false)}
               />
             </div>
           </div>

--- a/src/components/ui/image-with-zoom.tsx
+++ b/src/components/ui/image-with-zoom.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image"
 import { useState } from "react"
 import { cn } from "@/lib/utils"
+import { Skeleton } from "@/components/ui/skeleton"
 
 export interface ImageWithZoomProps {
   src: string
@@ -21,6 +22,7 @@ export default function ImageWithZoom({
 }: ImageWithZoomProps) {
   const [isHovered, setIsHovered] = useState(false)
   const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 })
+  const [isLoading, setIsLoading] = useState(true)
 
   const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
     if (!showZoomOnHover) return
@@ -49,12 +51,20 @@ export default function ImageWithZoom({
         onMouseLeave={handleMouseLeave}
       >
         <div className="relative h-[400px] w-full">
+          {isLoading && (
+            <Skeleton className="absolute inset-0 h-full w-full" />
+          )}
           <Image 
             src={src}
             fill
             alt={alt}
             style={{objectFit: 'cover'}}
-            className="transition-opacity duration-200"
+            className={cn(
+              "transition-opacity duration-200",
+              isLoading ? "opacity-0" : "opacity-100"
+            )}
+            onLoad={() => setIsLoading(false)}
+            onError={() => setIsLoading(false)}
           />
         </div>
       </div>

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,15 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("animate-pulse rounded-md bg-muted", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/src/components/ui/tile.tsx
+++ b/src/components/ui/tile.tsx
@@ -1,4 +1,7 @@
 import Image from 'next/image';
+import { useState } from 'react';
+import { cn } from "@/lib/utils";
+import { Skeleton } from "@/components/ui/skeleton";
 
 export interface TileProps {
     src: string,
@@ -7,14 +10,25 @@ export interface TileProps {
 }
 
 export function Tile(props: TileProps) {
+    const [isLoading, setIsLoading] = useState(true);
+    
     return (
-        <div>
+        <div className="relative">
+            {isLoading && (
+                <Skeleton className="absolute inset-0 h-full w-full" />
+            )}
             <Image 
                 src="/art-images/Forest-Floor.jpg"
                 alt="An Image of Forest Floor"
                 fill
                 priority
                 style={{objectFit: 'cover'}}
+                className={cn(
+                    "transition-opacity duration-200",
+                    isLoading ? "opacity-0" : "opacity-100"
+                )}
+                onLoad={() => setIsLoading(false)}
+                onError={() => setIsLoading(false)}
             />
         </div>
     )


### PR DESCRIPTION
- Add skeleton component via shadcn
- Implement loading states in ImageWithZoom, CardWithImage, and Tile components
- Add smooth opacity transitions from skeleton to loaded images
- Handle both onLoad and onError events to prevent infinite loading

🤖 Generated with [Claude Code](https://claude.ai/code)